### PR TITLE
Remove use of global variables

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,5 +1,5 @@
 console.log(" *** Server startup *** ");
-global.ROOT_DIR = __dirname;
+const ROOT_DIR = __dirname;
 console.log(" - loading express");
 var express = require('express');
 var app = express();
@@ -10,9 +10,11 @@ var morgan = require('morgan');
 console.log(" - loading body-parser");
 var bodyParser = require('body-parser');
 
-require(global.ROOT_DIR + '/server/walkDir');
+const walkDirectory = require(path.join(ROOT_DIR, 'server/walkDir'));
+const controllers = walkDirectory(ROOT_DIR + '/public/', 'js/controllers');
+const services = walkDirectory(ROOT_DIR + '/public/', 'js/services/');
 
-app.set('views', global.ROOT_DIR + '/views');
+app.set('views', ROOT_DIR + '/views');
 app.set('view engine', 'pug');
 
 app.use(bodyParser.urlencoded({ extended: false })); // parse application/x-www-form-urlencoded
@@ -20,8 +22,8 @@ app.use(bodyParser.json()); // parse application/json
 
 // Routes
 console.log(" - loading routes");
-app.use(express.static(path.join(global.ROOT_DIR, 'public'))); // serving static files
-require(global.ROOT_DIR + '/server/routes')(app); // non-direct routes
+app.use(express.static(path.join(ROOT_DIR, 'public'))); // serving static files
+require(path.join(ROOT_DIR, 'server/routes'))(app, controllers, services); // non-direct routes
 
 app.use(morgan('dev')); // output requests to console
 

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,10 +1,8 @@
 // main routing for all http-server-requests
 
-module.exports = function(app) {
+module.exports = function(app, controllers, services) {
 
-    global.controllers = global.walkDirectory(global.ROOT_DIR + '/public/', 'js/controllers');
-    global.services = global.walkDirectory(global.ROOT_DIR + '/public/', 'js/services/');
-    app.get('/', function(rq, rs) { rs.render('index', { controllers: global.controllers, services: global.services }) }); // GET index
+    app.get('/', function(rq, rs) { rs.render('index', { controllers: controllers, services: services }) }); // GET index
     app.get('/pages/:name', function(rq, rs) { rs.render('pages/' + rq.params.name + '/index') });
 
     // redirect all others to the index (HTML5 history)

--- a/server/walkDir.js
+++ b/server/walkDir.js
@@ -14,5 +14,4 @@ function walkDirectory(rootdir, subdir) {
     return results;
 }
 
-global.walkDirectory = walkDirectory;
 module.exports = walkDirectory;


### PR DESCRIPTION
## Summary
- remove `global` assignments from `walkDir` and routes
- pass directories and file lists to routes instead
- update server startup to rely on local variables

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68485b23ecd0832cbba564d4766931d3