### PR TITLE
Refactor walkDir to use async fs.promises

### DIFF
--- a/server/walkDir.js
+++ b/server/walkDir.js
@@ -1,16 +1,16 @@
-const fs = require('fs');
+const fs = require('fs/promises');
 
-function walkDirectory(rootdir, subdir) {
+async function walkDirectory(rootdir, subdir) {
     let results = [];
-    const list = fs.readdirSync(rootdir + subdir);
-    list.forEach(function(file) {
-        const stat = fs.statSync(rootdir + subdir + '/' + file);
+    const list = await fs.readdir(rootdir + subdir);
+    for (const file of list) {
+        const stat = await fs.stat(rootdir + subdir + '/' + file);
         if (stat && stat.isDirectory()) {
-            results = results.concat(walkDirectory(rootdir, subdir + '/' + file));
+            results = results.concat(await walkDirectory(rootdir, subdir + '/' + file));
         } else {
             results.push(subdir + '/' + file);
         }
-    });
+    }
     return results;
 }
 

--- a/test/walkDir.test.js
+++ b/test/walkDir.test.js
@@ -13,7 +13,7 @@ test('walkDirectory lists files recursively', async () => {
   fs.writeFileSync(path.join(tmp, 'a.txt'), 'a');
   fs.writeFileSync(path.join(sub, 'b.txt'), 'b');
 
-  const files = walkDirectory(tmp, '');
+  const files = await walkDirectory(tmp, '');
   assert.deepStrictEqual(files.sort(), ['/a.txt', '/sub/b.txt']);
 
   fs.rmSync(tmp, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- refactor server/walkDir.js to use the async `fs.promises` API
- update walkDir.test.js to await the async function

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684864f0f874832cbf824dd514d2747d